### PR TITLE
Shorthand Commands

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -1,18 +1,64 @@
-# Developer Guide
+# CCA Manager Developer Guide
+
+CCA Manager is a revolutionary all-in-one management tool that changes the way you can manage interest groups with unrivaled efficiency and simplicity. Its lightweight Command Line Interface (CLI) allows administrators to breeze through tasks quickly and easily while offering powerful features to advanced users.
+
+
+This developer guide is written to document the implementation of CCA Manager. This document is intended for people who
+are interested in learning more about the technical details of the various features and the organization of the application.
+
 
 ## Design & implementation
 
 {Describe the design and implementation of the product. Use UML diagrams and short code snippets where applicable.}
 
+### Input Parsing
+**Current Implementation**  
+The `Parser` class in `seedu.duke.backend` handles most of the input parsing. The `Parser` is a standalone class. Its purpose is to handle the conversion of read Strings from the `Ui` to UserInput objects
+safely for the rest of the program to handle. It implements the following operations:
+
+* `Parser#parse()` - Converts the supplied input `String` to a `UserInput` object
+* `Parser#checkCategory()` - Convert the supplied `String` to a `String` category. This function implements Shorthand category detection.
+* `Parser#sanitize()` - Check for unsupported, illegal or potentially malicious input and remove it from the `String`.
+
+Given below is an explanation on the logical flow of the `parse()` function.
+
+1. The supplied `String` is sent to `sanitize()` to remove any potentially unwanted input that may cause undefined application behavior.
+2. `sanitize()` will analyze the `String` and run a set list of checks to verify that the input is safe for the rest of the routine to handle.
+3. `parse()` will split the `String` to a `String[]` to identify the number of arguments.
+4. `checkCategory()` is invoked to identify if the command belongs to a specific category.
+5. A `HashMap<String,String>` is created to store all the arguments supplied by the user.
+6. A new `UserInput` object is created with the arguments in the HashMap, the category of the command and the command.
+7. The function returns the `UserInput` to the `Ui` for further execution.
+
+**Design Considerations**  
+Aspect: Statefulness of Parser object
+* Alternative 1 (Current Choice): Parser does not preserve state between parses.
+    * Pros: Easy to implement. Easy to test. Promotes use of single commands over multi-step commands.
+    * Cons: Unable to implement intelligent functionality where previous input influences the behavior of the next.
+    * Reason for choice: Our focus for this application is simplicity and efficiency. Having stateful commands runs counter to this design philosophy.
+* Alternative 2: Parser preserves stateful information
+    * Pros: Able to implement multi-step commands. Can easily implement confirmation step for commands that manipulate large volume of data.
+    * Cons: More complicated to implement. Harder to ensure the behaviour of the parser is consistent. Harder to debug.
+Aspect: Design of parser
+* Alternative 1 (Current Choice): Dedicated parser class creates an object to be passed into all other Command objects
+    * Pros: Allows other classes to check for the required arguments without having to do low level string handling. Enforces consistent parsing across all commands. Enables `/` arguments to be added and read in any order.
+    * Cons: Incurs additional overhead from adding an extra step between the input operation and the command invocation.
+* Alternative 2: Each Command handles its own input independently
+    * Pros: Command classes are free to simplify the parsing step depending on the required complexity of the command. No intermediate step and overhead.
+    * Cons: More difficult to enforce parsing standards across Commands. String manipulation becomes required in every command.
 
 ## Product scope
 ### Target user profile
 
-{Describe the target user profile}
+Our product targets people who manage interest groups and CCAs. 
+However, our software solution allows us to easily expand the target audience to target schools and corporate enterprise clients in the future.
 
 ### Value proposition
 
-{Describe the value proposition: what problem does it solve?}
+Management software is expensive and complex, training employees to use it is time-consuming. CCA Manager aims to solve these
+problems by offering an all-in-one solution focused on simplicity and efficiency. 
+Our use of industry standard csv format ensures compatibility with leading industry tools. 
+Shorthand Commands and Relative Time allow advanced users to enter up to 70% more commands per minute. 
 
 ## User Stories
 
@@ -23,7 +69,10 @@
 
 ## Non-Functional Requirements
 
-{Give non-functional requirements}
+1. Should work on any mainstream OS as long as it has Java 11 or above installed.
+2. Should be able to hold hundreds of thousands of data entries without losing the data.
+3. A user with average typing speed should be able to accomplish most of the tasks faster using commands than using the mouse.
+4. The program should support writing to a universally supported and easy to edit non-proprietary file format such as RFC 4180 .csv files.
 
 ## Glossary
 

--- a/src/main/java/seedu/duke/event/CommandEventAdd.java
+++ b/src/main/java/seedu/duke/event/CommandEventAdd.java
@@ -6,20 +6,32 @@ import seedu.duke.backend.UserInput;
 
 public class CommandEventAdd extends Command {
     private UserInput userInput;
+    private Event cachedEvent;
 
     @Override
     public String execute() {
-        Event m = new Event(userInput.getArg("n"), userInput.getArg("d"), userInput.getArg("t"));
-        String output = EventList.addEvent(m);
+        if (cachedEvent == null) {
+            return "Unable to create event! Please check your inputs again!";
+        }
+        String output = EventList.addEvent(cachedEvent);
         return output;
     }
 
     @Override
     public int validate(UserInput ui) {
         userInput = ui;
-        if (userInput.getCategory().equals("event") && userInput.getCommand().equalsIgnoreCase("addEvent")) {
-            if (ui.getNumArgs() == 3) {
-                if ((ui.getArg("n") != null) && (ui.getArg("d") != null) && (ui.getArg("t") != null)) {
+        if (userInput.getCategory().equals("event") && (userInput.getCommand().equalsIgnoreCase("addEvent")
+                || userInput.getCommand().equalsIgnoreCase("add")
+                || userInput.getCommand().equalsIgnoreCase("a"))) {
+            if (ui.getNumArgs() >= 3) {
+                if ((ui.getArg("n") == null) || (ui.getArg("d") == null) || (ui.getArg("t") == null)) {
+                    return ARGUMENT_ERR;
+                }
+                if ((ui.getArg("n").equals("")) || (ui.getArg("d").equals("")) || (ui.getArg("t").equals(""))) {
+                    return ARGUMENT_ERR;
+                }
+                cachedEvent = new Event(userInput.getArg("n"), userInput.getArg("d"), userInput.getArg("t"));
+                if (cachedEvent.date != null) {
                     return ACCEPT;
                 }
             }
@@ -32,6 +44,6 @@ public class CommandEventAdd extends Command {
 
     @Override
     public String help() {
-        return null;
+        return "Syntax: event addEvent /n <Name> /d <Date YYYY-MM-DD> /t <Time>";
     }
 }

--- a/src/main/java/seedu/duke/event/CommandEventDel.java
+++ b/src/main/java/seedu/duke/event/CommandEventDel.java
@@ -16,13 +16,15 @@ public class CommandEventDel extends Command {
 
     @Override
     public String help() {
-        return null;
+        return "Syntax: event addEvent <Index>";
     }
 
     @Override
     public int validate(UserInput ui) {
         userInput = ui;
-        if (ui.getCategory().equals("event") && ui.getCommand().equalsIgnoreCase("delEvent")) {
+        if (ui.getCategory().equals("event") && (ui.getCommand().equalsIgnoreCase("delEvent")
+                || ui.getCommand().equalsIgnoreCase("del")
+                || ui.getCommand().equalsIgnoreCase("d"))) {
             if (ui.getNumArgs() == 1) {
                 if ((ui.getArg("") != null)) {
                     return ACCEPT;

--- a/src/main/java/seedu/duke/event/CommandEventList.java
+++ b/src/main/java/seedu/duke/event/CommandEventList.java
@@ -15,7 +15,9 @@ public class CommandEventList extends Command {
     @Override
     public int validate(UserInput input) {
         this.userInput = input;
-        if (input.getCategory().equals("event") && input.getCommand().equalsIgnoreCase("listEvent")) {
+        if (input.getCategory().equals("event") && (input.getCommand().equalsIgnoreCase("listEvent")
+            || input.getCommand().equalsIgnoreCase("list")
+            || input.getCommand().equalsIgnoreCase("l"))) {
             return ACCEPT;
         } else {
             return NO_MATCH;

--- a/src/main/java/seedu/duke/finance/CommandFinanceAdd.java
+++ b/src/main/java/seedu/duke/finance/CommandFinanceAdd.java
@@ -3,6 +3,7 @@ package seedu.duke.finance;
 import seedu.duke.Command;
 import seedu.duke.DukeFinanceAddDescriptionLostException;
 import seedu.duke.backend.UserInput;
+
 import java.util.logging.Logger;
 
 public class CommandFinanceAdd extends Command {
@@ -20,26 +21,33 @@ public class CommandFinanceAdd extends Command {
         String[] contents = input.trim().split(" ");
         int length = contents.length;
         String item = "";
-        for (int i = 0;i < length - 1;i++) {
+        for (int i = 0; i < length - 1; i++) {
             if (i == length - 2) {
                 item = item + contents[i];
             } else {
                 item = item + contents[i] + " ";
             }
         }
-        FinanceLog fl = new FinanceLog(item,Double.parseDouble(contents[length - 1]));
-        String output = FinanceList.addLog(fl);
-        logger.info("End adding...\n");
-        return output;
+        try {
+            FinanceLog fl = new FinanceLog(item, Double.parseDouble(contents[length - 1]));
+            String output = FinanceList.addLog(fl);
+            logger.info("End adding...\n");
+            return output;
+        } catch (NumberFormatException nfe) {
+            logger.warning("The input format is wrong.\n");
+            throw new DukeFinanceAddDescriptionLostException();
+        }
     }
 
     @Override
     public String help() {
-        return "The format input to add a finance log is: hr addLog title value";
+        return "Syntax: hr addLog title value";
     }
 
     public int validate(UserInput ui) {
-        if (ui.getCategory().equals("finance") && ui.getCommand().equalsIgnoreCase("addlog")) {
+        if (ui.getCategory().equals("finance") && (ui.getCommand().equalsIgnoreCase("addlog")
+                || ui.getCommand().equalsIgnoreCase("add")
+                || ui.getCommand().equalsIgnoreCase("a"))) {
             userinput = ui;
             return ACCEPT;
         }

--- a/src/main/java/seedu/duke/finance/CommandFinanceDel.java
+++ b/src/main/java/seedu/duke/finance/CommandFinanceDel.java
@@ -23,9 +23,6 @@ public class CommandFinanceDel extends Command {
         if (ui.getCategory().equals("finance") && ui.getCommand().equalsIgnoreCase("dellog")
                 || ui.getCommand().equalsIgnoreCase("del")
                 || ui.getCommand().equalsIgnoreCase("d")) {
-            if (ui.getArg("") == null || ui.getArg("").equals("")) {
-                return ARGUMENT_ERR;
-            }
             try {
                 Integer.parseInt(ui.getArg(""));
             } catch (NumberFormatException e) {

--- a/src/main/java/seedu/duke/finance/CommandFinanceDel.java
+++ b/src/main/java/seedu/duke/finance/CommandFinanceDel.java
@@ -16,11 +16,21 @@ public class CommandFinanceDel extends Command {
 
     @Override
     public String help() {
-        return "The format of input to delete a log is: finance delLog index";
+        return "Syntax: finance delLog <index>";
     }
 
     public int validate(UserInput ui) {
-        if (ui.getCategory().equals("finance") && ui.getCommand().equalsIgnoreCase("dellog")) {
+        if (ui.getCategory().equals("finance") && ui.getCommand().equalsIgnoreCase("dellog")
+                || ui.getCommand().equalsIgnoreCase("del")
+                || ui.getCommand().equalsIgnoreCase("d")) {
+            if (ui.getArg("") == null || ui.getArg("").equals("")) {
+                return ARGUMENT_ERR;
+            }
+            try {
+                Integer.parseInt(ui.getArg(""));
+            } catch (NumberFormatException e) {
+                return ARGUMENT_ERR;
+            }
             userinput = ui;
             return ACCEPT;
         }

--- a/src/main/java/seedu/duke/finance/CommandFinanceSummary.java
+++ b/src/main/java/seedu/duke/finance/CommandFinanceSummary.java
@@ -18,7 +18,10 @@ public class CommandFinanceSummary extends Command {
     }
 
     public int validate(UserInput ui) {
-        if (ui.getCategory().equals("finance") && ui.getCommand().equalsIgnoreCase("summary")) {
+        if (ui.getCategory().equals("finance") && (ui.getCommand().equalsIgnoreCase("summary")
+                || ui.getCommand().equalsIgnoreCase("list")
+                || ui.getCommand().equalsIgnoreCase("s")
+                || ui.getCommand().equalsIgnoreCase("l"))) {
             userinput = ui;
             return ACCEPT;
         }

--- a/src/main/java/seedu/duke/hr/CommandAddMember.java
+++ b/src/main/java/seedu/duke/hr/CommandAddMember.java
@@ -24,7 +24,7 @@ public class CommandAddMember extends Command {
                     return ARGUMENT_ERR;
                 }
                 if ((input.getArg("n").equals("")) || (input.getArg("p").equals("")) || (input.getArg("e").equals(""))
-                        && (input.getArg("r").equals("")) || isInteger(input.getArg("p"))) {
+                        && (input.getArg("r").equals("")) || !isInteger(input.getArg("p"))) {
                     return ARGUMENT_ERR;
                 }
                 return ACCEPT;

--- a/src/main/java/seedu/duke/hr/CommandAddMember.java
+++ b/src/main/java/seedu/duke/hr/CommandAddMember.java
@@ -2,6 +2,7 @@ package seedu.duke.hr;
 
 import seedu.duke.Command;
 import seedu.duke.backend.UserInput;
+
 import static seedu.duke.hr.MemberList.isInteger;
 
 /**
@@ -15,12 +16,18 @@ public class CommandAddMember extends Command {
     @Override
     public int validate(UserInput input) {
         this.savedInput = input;
-        if (input.getCategory().equals("hr") && input.getCommand().equalsIgnoreCase("add")) {
-            if (input.getNumArgs() == 4) {
-                if ((input.getArg("n") != null) && (input.getArg("p") != null) && (input.getArg("e") != null)
-                        && (input.getArg("r") != null) && isInteger(input.getArg("p"))) {
-                    return ACCEPT;
+        if (input.getCategory().equals("hr") && (input.getCommand().equalsIgnoreCase("add")
+                || input.getCommand().equalsIgnoreCase("a"))) {
+            if (input.getNumArgs() >= 4) {
+                if ((input.getArg("n") == null) || (input.getArg("p") == null) || (input.getArg("e") == null)
+                        && (input.getArg("r") == null)) {
+                    return ARGUMENT_ERR;
                 }
+                if ((input.getArg("n").equals("")) || (input.getArg("p").equals("")) || (input.getArg("e").equals(""))
+                        && (input.getArg("r").equals("")) || isInteger(input.getArg("p"))) {
+                    return ARGUMENT_ERR;
+                }
+                return ACCEPT;
             }
             return ARGUMENT_ERR;
         } else {

--- a/src/main/java/seedu/duke/hr/CommandDelMember.java
+++ b/src/main/java/seedu/duke/hr/CommandDelMember.java
@@ -16,7 +16,8 @@ public class CommandDelMember extends Command {
     @Override
     public int validate(UserInput input) {
         this.savedInput = input;
-        if (input.getCategory().equals("hr") && input.getCommand().equalsIgnoreCase("delete")) {
+        if (input.getCategory().equals("hr") && input.getCommand().equalsIgnoreCase("delete")
+                || input.getCommand().equalsIgnoreCase("d")) {
             if (input.getNumArgs() == 1) {
                 if ((input.getArg("") != null) && isInteger(input.getArg(""))) {
 

--- a/src/main/java/seedu/duke/hr/CommandViewMember.java
+++ b/src/main/java/seedu/duke/hr/CommandViewMember.java
@@ -13,7 +13,8 @@ public class CommandViewMember extends Command {
     @Override
     public int validate(UserInput input) {
         this.savedInput = input;
-        if (input.getCategory().equals("hr") && input.getCommand().equalsIgnoreCase("list")) {
+        if (input.getCategory().equals("hr") && input.getCommand().equalsIgnoreCase("list")
+            || input.getCommand().equalsIgnoreCase("l")) {
             return ACCEPT;
         } else {
             return NO_MATCH;


### PR DESCRIPTION
Add shorthand commands for all existing Finance, HR and Event commands

**This is a major update that changes many files, please review the code thoroughly!**
Error checking has also been enhanced there are now far less unhandled errors so you might notice that there were a lot of re-organization of some of the codes in commands to better handle errors.

commands like "addlog" now support both "add" and "a"
here are an example of some of the possible commands now with shorthand

```
f l
f s (both finance list and finance summary will also trigger summary, to help people since our other two 'list' commands use 'list')
f a iPhone 12 Pro Max 1800
f d 1
e a /n CS2113T Tutorial /d next fri /t 2pm
e d 1
e l
h a /n John /e a@a.com /p 1234 /r Manager
h d 2
h l
```
